### PR TITLE
Use SmartyStreets geocoding API for addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ environment*
 data/geojsons/*
 
 *.DS_Store
+
+__pycache__

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 1. Geocode a given single-line address to a (latitude, longitude) pair using a
    remote (forward) geocoding service.
    
-   In the prototype, we're using Google's service, but this is swappable.  The
+   We're currently using SmartyStreets' service, but this is swappable.  The
    important point is the quality and robustness of the geocoding given dirty
    data.  Even rough geocoding results can be useful though, as Census tracts
    are fairly large.  I believe that as long as we submit addresses free of
    any linkage to other data, we can use a commercially-available geocoding
    service without PHI concerns, c.f.  [discussion on
-   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700).
+   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700). 
+   To use SmartyStreet's geocoding service, users must [register at their website](http://smartystreets.com/) and add their authentication keys as environment 
+   variables (see the [conda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) for help).
 
 2. Find the Census tract polygon containing the geocoded (latitude, longitude).
 
@@ -56,3 +58,11 @@ Stored in the `data/` directory.
 
   These are not checked into version control and must be converted locally by
   running `snakemake geojsons`.  `ogr2ogr` must be installed.
+
+## Development
+
+If you have conda installed, then simply install the project dependencies using 
+`conda env create -f geocoding_env_conda.yaml`. There is one additional 
+requirement not available through conda that needs to be installed. While 
+inside of your `geocoding` conda environment, please run 
+`pip install smartystreets-python-sdk`.

--- a/address_to_census_tract.py
+++ b/address_to_census_tract.py
@@ -4,20 +4,48 @@ Takes a file containing a list of addresses, one per line, and returns their
 associated census tract within Washington.
 
 To run:
-    ./address_to_census_tract.py
+    ./address_to_census_tract.py {filepath}
+
+Examples:
+    ./address_to_census_tract.py data/test/testset.json
+    ./address_to_census_tract.py data/test/testset.csv 
 
 Requirements:
-    geocoder
     shapely
+    pandas
+    smartystreets_python_sdk
 """
-import geocoder
 import json
+import os
+from sys import argv
+from textwrap import dedent
 from shapely.geometry import shape, Point
-from sys import stderr
+import logging
+import pandas as pd
+from smartystreets_python_sdk import StaticCredentials, exceptions, ClientBuilder
+from smartystreets_python_sdk.us_street import Lookup
+from smartystreets_python_sdk.us_extract import Lookup as ExtractLookup
+
+LOG = logging.getLogger(__name__)
 
 
 def main():
-    with open("data/test/testset.json", encoding = "UTF-8") as file:
+    if len(argv) == 0:
+        raise IndexError("A filename argument is required")
+    if argv[1].endswith('.json'):
+        process_json(argv[1])
+    elif argv[1].endswith('.csv'):
+        process_csv(argv[1])
+    else:
+        raise ValueError(dedent(f"""
+        Unknown file extension for file named «{argv[1]}». 
+        Please choose from one of the following file extensions:
+            * .csv 
+            * .json
+    """))
+
+def process_json(file_path: str):
+    with open(file_path, encoding = "UTF-8") as file:
         testset = [ json.loads(line) for line in file ]
 
     tracts = load_geojson("data/geojsons/Washington_2016.geojson")
@@ -25,34 +53,123 @@ def main():
     for record in testset:
         address = record["address"]
 
+        standard_address = None
+        latlng = None
         tract = None
-        latlng = address_to_latlng(address)
+        response = lookup_address(address)
 
-        if latlng:
+        if response and response['lat'] and response['lng']:
+            standard_address = response['standard_address']
+            latlng = [response['lat'], response['lng']]
             tract = latlng_to_polygon(latlng, tracts)
 
-            if not tract:
-                print(f"failed to find tract for {latlng}", file = stderr)
         else:
-            print(f"failed to geocode {address}", file = stderr)
+            LOG.warning(f"Failed to geocode {address}")
 
-        # GEOID is the nationally-unique tract identifier
         result = {
+            "address": standard_address,
             "latlng": latlng,
-            "tract": tract.get("properties", {}).get("GEOID") if tract else None,
+            "tract": tract,
         }
 
         print(json.dumps({ **record, "result": result }))
 
-
-def address_to_latlng(address):
-    """Convert an address string to a list of latitude, longitude coordinates.
-
-    Currently uses Google's geocoder API for geocoding, but this could be
-    replaced with other geocoder implementations.
+def process_csv(file_path: str):
     """
-    return geocoder.google(address).latlng
+    Given a *file_path* to a CSV, processes the `address` column and adds 
+    extra columns for a standardized address, latitude and longitude
+    coordinates, and census tract. If a given address is invalid, these new 
+    columns are left blank. Dumps the new table to stdout. 
 
+    To minimize costs, an address should only be looked up once (via 
+    `lookup_address()`).
+    """
+    df = pd.read_csv(file_path)
+    tracts = load_geojson("data/geojsons/Washington_2016.geojson")
+
+    response = pd.Series(df['address'].apply(lookup_address))
+
+    # Parse response object to create columns of interest
+    df['standard_address'] = response.apply(lambda x: x and x['standard_address'])
+    df['lat'] = response.apply(lambda x: x and x['lat'])
+    df['lng'] = response.apply(lambda x: x and x['lng'])
+
+    latlng = pd.Series(list(zip(df['lat'], df['lng'])))
+    df['final_tract'] = latlng.apply(lambda x: latlng_to_polygon(x, tracts))
+    
+    print(df.to_csv(index=False)) 
+
+def smartystreets_client_builder():
+    """
+    Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
+    credentials from the environment variables ``SMARTYSTREETS_AUTH_ID`` and
+    ``SMARTYSTREETS_AUTH_TOKEN``.
+    """
+    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
+    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
+
+    return ClientBuilder(StaticCredentials(auth_id, auth_token))
+
+def lookup_address(address: str) -> dict:
+    """
+    Given an address, returns a dict containing a standardized address and 
+    lat/long coordinates from SmartyStreet's US Street geocoding API.
+    """
+    client = smartystreets_client_builder().build_us_street_api_client()
+
+    lookup = Lookup()
+    lookup.street = address
+    lookup.candidates = 1
+    lookup.match = "Invalid"  # Most permissive
+    
+    try:
+        client.send_lookup(lookup)
+    except exceptions.SmartyException as err:
+        LOG.exception(err)
+        return
+
+    result = lookup.result
+    if not result:  # Invalid address
+        result = extract_address(address)
+        if not result:
+            LOG.warning(f"Could not look up address {address}")
+            return 
+
+    first_candidate = result[0]
+
+    return {"standard_address": standard_address(first_candidate),
+            "lat": first_candidate.metadata.latitude,
+            "lng": first_candidate.metadata.longitude}
+
+def extract_address(text: str):
+    """
+    Given arbitrary *text*, returns a result from the SmartyStreet's US Extract
+    geocoding API containing information about an address connected to the text.
+
+    Note that this API is not consistent with the US Street API, and the lookup
+    and responses must be handled differently.
+    """
+    client = smartystreets_client_builder().build_us_extract_api_client()
+    lookup = ExtractLookup()
+    lookup.text = text
+
+    result = client.send(lookup)
+    metadata = result.metadata
+    
+    addresses = result.addresses
+    for address in addresses:
+        return address.candidates
+
+def standard_address(candidate) -> str:
+    """
+    Given a result object *candidate* from SmartyStreets geocoding API, return a 
+    standardized address.
+    """
+    standard_address = candidate.delivery_line_1
+    if candidate.delivery_line_2:
+        standard_address += ' ' + candidate.delivery_line_2
+
+    return standard_address + ' ' + candidate.last_line
 
 def load_geojson(geojson_filename):
     """Read GeoJSON file and return a list of features converted to shapes."""
@@ -65,23 +182,24 @@ def load_geojson(geojson_filename):
             for feature in geojson["features"]
     ]
 
-
-def latlng_to_polygon(latlng, polygons):
+def latlng_to_polygon(latlng: list, polygons):
     """
-    Find the first polygon in *polygons* which contains the *latlng* and return
-    the polygon, else None.
+    Find the first polygon in *polygons* (loaded from file) which contains the 
+    *latlng* and return the polygon, else None.
     """
-
+    
     # Ye olde lat/lng vs. lng/lat schism rears its head.
     lat, lng = latlng
+
     point = Point(lng, lat)
 
     for polygon in polygons:
         if polygon["shape"].contains(point):
-            return polygon
+            # GEOID is the nationally-unique tract identifier
+            return polygon.get("properties", {}).get("GEOID") 
 
+    LOG.warning(f"Failed to find tract for {latlng}")
     return None
-
 
 if __name__ == '__main__':
     main()

--- a/data/test/testset.csv
+++ b/data/test/testset.csv
@@ -1,0 +1,11 @@
+address,tract
+"1100 Fairview Ave N, Seattle, WA 98109",          "53033006600"
+"1959 NE Pacific St, Seattle, WA 98195",           "53033005302"
+"7755 E Marginal Way S, Seattle, WA 98108",        "53033010900"
+"837 N 34th St #220, Seattle, WA 98103",           "53033004900"
+"8864, 910 N Northlake Way, Seattle, WA 98103",    "53033005400"
+"2360 43rd Ave E, Seattle, WA 98112",              "53033006300"
+"7312 West Green Lake Dr N, Seattle, WA 98103",    "53033004600"
+"3801 Discovery Park Blvd, Seattle, WA 98199",     "53033005700"
+"5900 Lake Washington Blvd S, Seattle, WA 98118",  "53033010200"
+"4025 Delridge Way SW #400, Seattle, WA 98106",    "53033009900"

--- a/geocoding_env_conda.yaml
+++ b/geocoding_env_conda.yaml
@@ -4,7 +4,7 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- geocoder
 - shapely
 - python=3.6*
 - snakemake
+- pandas


### PR DESCRIPTION
EDIT: see latest commit message for updated info.

vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
These changes swapped Google's geocoding API for SmartyStreet's API.
The HTTP GET request requires an authentication token and ID which are
not tracked through git and need to be added in a separate file,
`environment.py`. An example of a valid `environment.py` configuration
is viewable at `example.environment.py`. These authentication strings
are currently imported as global variables in
`address_to_census_tract.py`.

The program currently works by passing SmartyStreets a free text
address via the `street` parameter. There are a couple of assumptions
made about addresses in order for this program to work. Namely,
    1. A street address contains at least one letter, [a-z] (case
    insensitive).
    2. A street address comes before a zip code in an address.

We do not assume that an address is comma-separated.

If an address lookup fails on the first attempt (receives a status code
of 200 but returns no JSON object), then a second attempt is made to
lookup the address. In the second attempt, the program
    1. Splits the address (string) on any commas, converting it into a
    list.
    2. Removes the first index of the list if it contains only numbers.
    For example, in the original address `100, 123 Main St.`, `100`
    would be removed from the list.
    3. Finds and removes a partial string matching the pattern
    `#.*(?\s)` (a pound sign followed by anything with an optional
    space). In the original address `123 Main St. #100`, `#100` would be
    removed.

Removing these unit or suite numbers was essential in getting the
SmartyStreets API to find matches at certain addresses in the
`testset.json` file.