### PR TITLE
Multiple client address deidentification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ environment*
 data/geojsons/*
 
 *.DS_Store
+
+__pycache__

--- a/README.md
+++ b/README.md
@@ -1,58 +1,63 @@
 # Geocoding addresses into 2016 Census tracts
 
-`address_to_census_tract.py` prototypes address to Census tract conversion.  It uses a two-step process:
+`src/address_to_census_tract.py` performs address to Census tract conversion.  It uses a two-step process:
 
-1. Geocode a given single-line address to a (latitude, longitude) pair using a
-   remote (forward) geocoding service.
+1. Geocode a given single-line address to a (latitude, longitude) pair using a remote (forward) 
+geocoding service.
    
-   In the prototype, we're using Google's service, but this is swappable.  The
+   We're currently using SmartyStreets' service, but this is swappable.  The
    important point is the quality and robustness of the geocoding given dirty
    data.  Even rough geocoding results can be useful though, as Census tracts
    are fairly large.  I believe that as long as we submit addresses free of
    any linkage to other data, we can use a commercially-available geocoding
    service without PHI concerns, c.f.  [discussion on
-   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700).
+   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700). 
+   To use SmartyStreet's geocoding service, users must [register at their website](http://smartystreets.com/) and add their authentication keys as environment 
+   variables (see the [conda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) for help).
 
 2. Find the Census tract polygon containing the geocoded (latitude, longitude).
 
-   This can be done locally very easily given an off-the-shelf geospatial
-   library and publicly available Census geodata.
+   This can be done locally very easily given an off-the-shelf geospatial library and publicly 
+   available Census geodata.
 
-Note that the geocoding result may have variable specificity.  If an address
-can only be geocoded to "Seattle", then the geocoder may return Seattle's
-centroid.  This would artificially inflate the Census tracts containing the
-centroids returned for non-specific locations.
+Note that the geocoding result may have variable specificity.  If an address can only be geocoded to
+"Seattle", then the geocoder may return Seattle's centroid.  This would artificially inflate the 
+Census tracts containing the centroids returned for non-specific locations.
 
-We're not using the [Census' own
-geocoder](https://www.census.gov/geo/maps-data/data/geocoder.html), even
-though it can go directly to a Census tract, because its address coverage
-isn't great and it is not robust to bad addresses. As noted by the Census' own
-documentation, this is especially for business addresses, which we will be
-collecting as places of work.
+We're not using the [Census' own geocoder](https://www.census.gov/geo/maps-data/data/geocoder.html),
+even though it can go directly to a Census tract, because its address coverage isn't great and it is
+not robust to bad addresses. As noted by the Census' own documentation, this is especially for 
+business addresses, which we will be collecting as places of work.
 
 ## Data
 
 Stored in the `data/` directory.
 
-* `states.txt` contains a mapping of ANSI FIPS codes and USPS abbreviations for
-  all states, as described at
-  <https://www.census.gov/geo/reference/ansi_statetables.html>.  This file was
-  downloaded unmodified from
-  <http://www2.census.gov/geo/docs/reference/state.txt>.
+* `states.txt` contains a mapping of ANSI FIPS codes and USPS abbreviations for all states, as 
+  described at <https://www.census.gov/geo/reference/ansi_statetables.html>.  This file was
+  downloaded unmodified from <http://www2.census.gov/geo/docs/reference/state.txt>.
 
-* `omitted_states.txt` lists the _names_ of states we want to omit from
-  downloads of census tracts, with reasons provided in comments.
+* `omitted_states.txt` lists the _names_ of states we want to omit from downloads of census tracts, 
+  with reasons provided in comments.
 
 * `tracts/tl_2016_${state_fips_code}_tract.{dbf,prj,shp,shp.xml,shx}` are the
-  2016 Census tract Shapefiles and supporting files for each state, as
-  described at <https://www.census.gov/geo/maps-data/data/tiger-line.html>.
+  2016 Census tract Shapefiles and supporting files for each state, as described at 
+  <https://www.census.gov/geo/maps-data/data/tiger-line.html>.
 
   These are not checked into version control and must be downloaded locally by
-  running `snakemake tracts`.  Do not download the files in parallel or
-  repeatedly or the Census will likely ban your IP address!
+  running `snakemake tracts`.  Do not download the files in parallel or repeatedly or the Census 
+  will likely ban your IP address!
 
-* `tracts/tl_2016_${state_fips_code}_tract.geojson` are the Shapefiles
-  converted to GeoJSON, which is a slightly more useful format.
+* `tracts/tl_2016_${state_fips_code}_tract.geojson` are the Shapefiles converted to GeoJSON, which 
+  is a slightly more useful format.
 
   These are not checked into version control and must be converted locally by
   running `snakemake geojsons`.  `ogr2ogr` must be installed.
+
+## Development
+
+If you have conda installed, then simply install the project dependencies using 
+`conda env create -f geocoding_env_conda.yaml`. There is one additional 
+requirement not available through conda that needs to be installed. While 
+inside of your `geocoding` conda environment, please run 
+`pip install smartystreets-python-sdk`.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 1. Geocode a given single-line address to a (latitude, longitude) pair using a
    remote (forward) geocoding service.
    
-   In the prototype, we're using Google's service, but this is swappable.  The
+   We're currently using SmartyStreets' service, but this is swappable.  The
    important point is the quality and robustness of the geocoding given dirty
    data.  Even rough geocoding results can be useful though, as Census tracts
    are fairly large.  I believe that as long as we submit addresses free of
    any linkage to other data, we can use a commercially-available geocoding
    service without PHI concerns, c.f.  [discussion on
-   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700).
+   #data-transfer](https://seattle-flu-study.slack.com/archives/CDTUFFQCU/p1544570425008700). 
+   To use SmartyStreet's geocoding service, users must [register at their website](http://smartystreets.com/) and add their authentication keys as environment 
+   variables (see the [conda documentation](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables) for help).
 
 2. Find the Census tract polygon containing the geocoded (latitude, longitude).
 
@@ -56,3 +58,11 @@ Stored in the `data/` directory.
 
   These are not checked into version control and must be converted locally by
   running `snakemake geojsons`.  `ogr2ogr` must be installed.
+
+## Development
+
+If you have conda installed, then simply install the project dependencies using 
+`conda env create -f geocoding_env_conda.yaml`. There is one additional 
+requirement not available through conda that needs to be installed. While 
+inside of your `geocoding` conda environment, please run 
+`pip install smartystreets-python-sdk`.

--- a/address_to_census_tract.py
+++ b/address_to_census_tract.py
@@ -1,58 +1,306 @@
 #!/usr/bin/env python3
 """
-Takes a file containing a list of addresses, one per line, and returns their
-associated census tract within Washington.
+Takes a file containing addresses, one per line, and returns the data with a new
+    column or key containing an associated census tract. Removes the original
+    identifying address data.
 
 To run:
-    ./address_to_census_tract.py
+    `./src/address_to_census_tract.py {filepath} --institute {institution}`
+    or
+    `./src/address_to_census_tract.py {filepath} --street {street column}`
+
+Help:
+    `./src/address_to_census_tract.py --help`
+
+Examples:
+    `./src/address_to_census_tract.py data/test/testset.json --institute default`
+    `./src/address_to_census_tract.py data/test/testset.csv -s address`
 
 Requirements:
-    geocoder
     shapely
+    pandas
+    xlrd (pandas Excel compatibility)
+    smartystreets_python_sdk
 """
-import geocoder
 import json
+import os
+from sys import argv
+from textwrap import dedent
 from shapely.geometry import shape, Point
-from sys import stderr
+import logging
+import pandas as pd
+from smartystreets_python_sdk import StaticCredentials, exceptions, ClientBuilder
+from smartystreets_python_sdk.us_street import Lookup
+from smartystreets_python_sdk.us_extract import Lookup as ExtractLookup
+import config
+import click
+
+LOG = logging.getLogger(__name__)
+
+@click.command()
+@click.argument('filepath', required=True, type=click.Path(exists=True))
+@click.option('-i', '--institute', type=click.Choice(['UW', 'default']), 
+    default='default', help='The acronym representing the institution.')
+@click.option('-s', '--street', default=None, 
+    help='Key name for address street. Can also accept an entire address as free text')
+@click.option('--street2', default=None, 
+    help='Key name for address street second line')
+@click.option('--secondary', default=None, 
+    help='Key name for address secondary information (e.g. address line 3)')
+@click.option('-c', '--city', default=None, 
+    help='Key name for address city')
+@click.option('--state', default=None, 
+    help='Key name for address state')
+@click.option('-z', '--zipcode', default=None, 
+    help='Key name for address zipcode')
 
 
-def main():
-    with open("data/test/testset.json", encoding = "UTF-8") as file:
-        testset = [ json.loads(line) for line in file ]
+def address_to_census_tract(filepath, institute, **kwargs):
+    """
+    Given a *filepath* to a JSON, CSV, or Excel file (XLSX or XLS), de-identifies
+    addresses contained within the data by converting them to census tracts and
+    then removing the original address data. 
+
+    An *institute*-specific configuration mapping key names of addresses to
+    SmartyStreets geocoding API is loaded if the optional *kwargs* specifying
+    custom configuration are all None.
+
+    If optional *kwargs* are used, then then the program ignores the *institute*
+    declaration and proceeds with the custom configuration.
+
+    Note: If providing more than one, optional keyword argument, it is CRITICAL 
+    to provide them in the following order: \n
+        -s/--street \n
+        --street2 \n
+        --secondary \n
+        -c/--city \n
+        --state \n
+        -z/--zipcode
+    """
+
+    # TODO validate that no two keywords have the same value 
+
+    custom_address_config = not all(arg is None for arg in kwargs.values())
+
+    if custom_address_config:
+        address_map = kwargs
+    else:
+        address_map = config.ADDRESS_CONFIG[institute.lower()]
+        LOG.info(f"Using «{institute}» institutional configuration.")
+
+    if filepath.endswith('.json'):
+        process_json(filepath, address_map) 
+    elif filepath.endswith(('.csv', '.xlsx', '.xls')):
+        process_csv_or_excel(filepath, address_map)
+    else:
+        raise UnsupportedFileExtensionError(dedent(f"""
+        Unsupported file extension for file «{filepath}». 
+        Please choose from one of the following file extensions:
+            * .csv 
+            * .xls
+            * .xlsx
+            * .json
+    """))
+
+def process_json(file_path: str, address_map: dict):
+    """
+    Given a *file_path* to a JSON file, processes the relevant keys containing
+    address data (from *address_map*) and generates an extra key for census 
+    tract data. Raises a :class:`NoAddressDataFoundError` if the address mapping
+    is invalid and yields no matching keys from the address data. 
+    
+    If a given address is invalid, `census_tract` is left blank. 
+    
+    To minimize costs, an address should only be looked up once (via 
+    :func:`lookup_address`).
+
+    Dumps the generated JSON data to stdout. 
+    """
+
+    with open(file_path, encoding = "UTF-8") as file:
+        data = [ json.loads(line) for line in file ]
 
     tracts = load_geojson("data/geojsons/Washington_2016.geojson")
 
-    for record in testset:
-        address = record["address"]
+    for record in data:
+        # Subset to address-relevant columns only and store separately
+        address = { key: record[key] for key in record if key in address_map.values() }
 
+        if not address: 
+            raise NoAddressDataFoundError(record.keys(), address_map)  
+            
+        response = lookup_address(address, address_map)
+        latlng = None
         tract = None
-        latlng = address_to_latlng(address)
 
-        if latlng:
+        # Extract lat/lng from response object 
+        if response and response['lat'] and response['lng']:
+            latlng = [response['lat'], response['lng']]
             tract = latlng_to_polygon(latlng, tracts)
 
-            if not tract:
-                print(f"failed to find tract for {latlng}", file = stderr)
         else:
-            print(f"failed to geocode {address}", file = stderr)
+            LOG.warning(dedent(f"""
+            Failed to geocode {address}.
+            """))
 
-        # GEOID is the nationally-unique tract identifier
-        result = {
-            "latlng": latlng,
-            "tract": tract.get("properties", {}).get("GEOID") if tract else None,
-        }
+        # Drop identifiable address keys 
+        result = {k: record[k] for k in record if k not in address}
+        result["census_tract"] = tract
 
-        print(json.dumps({ **record, "result": result }))
+        print(json.dumps(result))
 
-
-def address_to_latlng(address):
-    """Convert an address string to a list of latitude, longitude coordinates.
-
-    Currently uses Google's geocoder API for geocoding, but this could be
-    replaced with other geocoder implementations.
+def process_csv_or_excel(file_path: str, address_map: dict):
     """
-    return geocoder.google(address).latlng
+    Given a *file_path* to a CSV or Excel file, processes the relevant columns
+    containing address data (from *address_map*) and generates an extra column 
+    census tract data. Raises a :class:`NoAddressDataFoundError` if the address
+    mapping is invalid and yields no matching columns on the address data.
+    
+    If a given address is invalid, `census_tract` is left blank. 
+    
+    Saves the new table at `data/test/out.csv`. 
 
+    To minimize costs, an address should only be looked up once (via 
+    :func:`lookup_address`).
+    """
+    if file_path.endswith('.csv'):
+        df = pd.read_csv(file_path)
+    else:
+        df = pd.read_excel(file_path)
+
+    tracts = load_geojson("data/geojsons/Washington_2016.geojson")
+
+    # Subset to address-relevant columns only and store separately
+    address_columns = [ col for col in df.columns if col in address_map.values() ]
+    if not address_columns:
+        raise NoAddressDataFoundError(df.columns, address_map)  
+  
+    address = pd.Series(df[address_columns].to_dict(orient='records'))
+    response = pd.Series(address.apply(lambda x: lookup_address(x, address_map)))
+
+    # Extract lat/lng from response object 
+    df['lat'] = response.apply(lambda x: x and x['lat'])
+    df['lng'] = response.apply(lambda x: x and x['lng'])
+    latlng = pd.Series(list(zip(df['lat'], df['lng'])))
+
+    df['census_tract'] = latlng.apply(lambda x: latlng_to_polygon(x, tracts))
+    
+    # Drop identifiable address columns
+    df = df.drop(columns=address_columns + ['lat', 'lng'])
+    df.to_csv('data/test/out.csv', index=False) 
+
+def lookup_address(address: dict, address_map: dict) -> dict:
+    """
+    Given an *address*, returns a dict containing a standardized address and 
+    lat/long coordinates from the first address candidate from SmartyStreets 
+    US Street geocoding API.
+
+    Note that this functionality works regardless of whether a given address is 
+    broken into pieces (street, city, zipcode, etc.) or is a free text lookup 
+    (and only the `street` parameter is used).
+    """
+    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
+    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
+
+    credentials = StaticCredentials(auth_id, auth_token)
+    client = ClientBuilder(credentials).build_us_street_api_client()
+    
+    lookup = us_street_lookup(address, address_map)
+    if not lookup.street:
+        LOG.warning(dedent(f"""
+        No given street address for {address}. 
+        Currently lookups are only possible with a street address.
+        """))
+        return
+
+    try:
+        client.send_lookup(lookup)
+    except exceptions.SmartyException as err:
+        LOG.exception(err)
+        return
+
+    result = lookup.result
+    if not result:  # Invalid address. Try again.
+        LOG.info(dedent(f"""
+        No match found for given address. Extracting address from text
+        """))
+        address_values = ', '.join([ str(val) for val in list(address.values()) if val ])
+        result = extract_address(credentials, address_values) 
+        if not result:
+            LOG.warning(dedent(f"""
+            Could not look up address {address}.
+            """))
+            return 
+
+    return {"lat": result[0].metadata.latitude,
+            "lng": result[0].metadata.longitude}
+
+def us_street_lookup(address: dict, api_map: dict) -> Lookup:
+    """
+    Creates and returns a SmartyStreets US Street API Lookup object for a given 
+    *address*. The *address* keys are mapped to the SmartyStreets API using the
+    given *api_map*. 
+
+    Raises a AddressTranslationNotFoundError if a mapped key from *api_map* 
+    does not exist in *address*.
+    """
+    truthy_api_map_values = set( api_map[key] for key in api_map if api_map[key] )
+    if not truthy_api_map_values.issubset(set(address.keys())):
+        raise AddressTranslationNotFoundError(address.keys(), api_map)
+
+    lookup = Lookup()
+
+    lookup.street = api_map['street'] and address[api_map['street']]
+    lookup.street2 = api_map['street2'] and address[api_map['street2']]
+    lookup.secondary = api_map['secondary'] and address[api_map['secondary']]
+    lookup.city = api_map['city'] and address[api_map['city']]
+    lookup.state = api_map['state'] and address[api_map['state']]
+    lookup.zipcode = api_map['zipcode'] and address[api_map['zipcode']]
+
+    lookup.candidates = 1
+    lookup.match = "Invalid"  # Most permissive
+    return lookup
+    
+def extract_address(credentials, text: str):
+    """
+    Given arbitrary *text* and *credentials* to SmartyStreets' geocoding APIs, 
+    returns a result from the SmartyStreets US Extract API containing 
+    information about an address connected to the text.
+
+    Note that this API is not consistent with the US Street API, and the lookup
+    and responses must be handled differently.
+
+    Assumes addresses are given in the correct order # TODO enforce
+    """
+    client = ClientBuilder(credentials).build_us_extract_api_client()
+    lookup = ExtractLookup()
+    lookup.text = text
+
+    result = client.send(lookup)    
+    addresses = result.addresses
+    for address in addresses:
+        return address.candidates
+
+def latlng_to_polygon(latlng: list, polygons):
+    """
+    Find the first polygon in *polygons* (loaded from file) which contains the 
+    *latlng* and return the polygon, else None.
+    """
+    
+    # Ye olde lat/lng vs. lng/lat schism rears its head.
+    lat, lng = latlng
+
+    point = Point(lng, lat)
+
+    for polygon in polygons:
+        if polygon["shape"].contains(point):
+            # GEOID is the nationally-unique tract identifier
+            return polygon.get("properties", {}).get("GEOID") 
+
+    LOG.warning(dedent(f"""
+    Failed to find tract for {latlng}.
+    """))
+    return None
 
 def load_geojson(geojson_filename):
     """Read GeoJSON file and return a list of features converted to shapes."""
@@ -66,22 +314,67 @@ def load_geojson(geojson_filename):
     ]
 
 
-def latlng_to_polygon(latlng, polygons):
+class UnsupportedFileExtensionError(ValueError):
     """
-    Find the first polygon in *polygons* which contains the *latlng* and return
-    the polygon, else None.
+    Raised by :func:`address_to_census_tract` when the given filepath ends with 
+    an unsupported extension.
     """
+    pass
 
-    # Ye olde lat/lng vs. lng/lat schism rears its head.
-    lat, lng = latlng
-    point = Point(lng, lat)
 
-    for polygon in polygons:
-        if polygon["shape"].contains(point):
-            return polygon
+class InvalidAddressMappingError(KeyError):
+    """
+    Base class for errors related to the address mapping from config.
 
-    return None
+    *address_keys* and *address_map* can be used by child classes for custom
+    error messages.
+
+    """
+    def __init__(self, address_keys: list, address_map: dict):
+        self.address_keys = address_keys
+        self.address_map = address_map
+
+
+class AddressTranslationNotFoundError(InvalidAddressMappingError):
+    """
+    Raised by :func:`us_street_lookup` when a given *api_map* contains a key 
+    with a truthy value but the key is not present among the given address keys.
+    """
+    def __str__(self):
+        return dedent(f"""
+            The address map contains values not present in the given address.
+            
+            Address keys are:
+                {list(self.address_keys)}
+            
+            No match found for 
+                {[ self.address_map[key] for key in self.address_map if self.address_map[key] 
+                   and self.address_map[key] not in self.address_keys ]}
+
+            The address mapping is:
+                {json.dumps(self.address_map, indent=16)}
+            """)
+
+
+class NoAddressDataFoundError(InvalidAddressMappingError):
+    """
+    Raised by :func:`process_json` or :func:`process_csv_or_excel` when the 
+    address configuration from `config` does not map to any keys or columns on 
+    the given data.
+    """
+    def __str__(self):
+        return dedent(f"""\n
+            Could not find any address data using the address mapping:
+                {json.dumps(self.address_map, indent=16)}
+            These keys were considered when looking for an address:
+                {list(self.address_keys)}
+
+            Did you forget to provide an institution or a custom configuration?
+            Please check your address mapping in `config.py` or run
+                `src/address_to_census_tract.py --help` 
+            and try again.
+            """)
 
 
 if __name__ == '__main__':
-    main()
+    address_to_census_tract()

--- a/address_to_census_tract.py
+++ b/address_to_census_tract.py
@@ -4,20 +4,48 @@ Takes a file containing a list of addresses, one per line, and returns their
 associated census tract within Washington.
 
 To run:
-    ./address_to_census_tract.py
+    ./address_to_census_tract.py {filepath}
+
+Examples:
+    ./address_to_census_tract.py data/test/testset.json
+    ./address_to_census_tract.py data/test/testset.csv 
 
 Requirements:
-    geocoder
     shapely
+    pandas
+    smartystreets_python_sdk
 """
-import geocoder
 import json
+import os
+from sys import argv
+from textwrap import dedent
 from shapely.geometry import shape, Point
-from sys import stderr
+import logging
+import pandas as pd
+from smartystreets_python_sdk import StaticCredentials, exceptions, ClientBuilder
+from smartystreets_python_sdk.us_street import Lookup
+from smartystreets_python_sdk.us_extract import Lookup as ExtractLookup
+
+LOG = logging.getLogger(__name__)
 
 
 def main():
-    with open("data/test/testset.json", encoding = "UTF-8") as file:
+    if len(argv) == 0:
+        raise IndexError("A filename argument is required")
+    if argv[1].endswith('.json'):
+        process_json(argv[1])
+    elif argv[1].endswith('.csv'):
+        process_csv(argv[1])
+    else:
+        raise ValueError(dedent(f"""
+        Unknown file extension for file named «{argv[1]}». 
+        Please choose from one of the following file extensions:
+            * .csv 
+            * .json
+    """))
+
+def process_json(file_path: str):
+    with open(file_path, encoding = "UTF-8") as file:
         testset = [ json.loads(line) for line in file ]
 
     tracts = load_geojson("data/geojsons/Washington_2016.geojson")
@@ -25,34 +53,123 @@ def main():
     for record in testset:
         address = record["address"]
 
+        standard_address = None
+        latlng = None
         tract = None
-        latlng = address_to_latlng(address)
+        response = lookup_address(address)
 
-        if latlng:
+        if response and response['lat'] and response['lng']:
+            standard_address = response['standard_address']
+            latlng = [response['lat'], response['lng']]
             tract = latlng_to_polygon(latlng, tracts)
 
-            if not tract:
-                print(f"failed to find tract for {latlng}", file = stderr)
         else:
-            print(f"failed to geocode {address}", file = stderr)
+            LOG.warning(f"Failed to geocode {address}")
 
-        # GEOID is the nationally-unique tract identifier
         result = {
+            "address": standard_address,
             "latlng": latlng,
-            "tract": tract.get("properties", {}).get("GEOID") if tract else None,
+            "tract": tract,
         }
 
         print(json.dumps({ **record, "result": result }))
 
-
-def address_to_latlng(address):
-    """Convert an address string to a list of latitude, longitude coordinates.
-
-    Currently uses Google's geocoder API for geocoding, but this could be
-    replaced with other geocoder implementations.
+def process_csv(file_path: str):
     """
-    return geocoder.google(address).latlng
+    Given a *file_path* to a CSV, processes the `address` column and adds 
+    extra columns for a standardized address, latitude and longitude
+    coordinates, and census tract. If a given address is invalid, these new 
+    columns are left blank. Dumps the new table to stdout. 
 
+    To minimize costs, an address should only be looked up once (via 
+    `lookup_address()`).
+    """
+    df = pd.read_csv(file_path)
+    tracts = load_geojson("data/geojsons/Washington_2016.geojson")
+
+    response = pd.Series(df['address'].apply(lookup_address))
+
+    # Parse response object to create columns of interest
+    df['standard_address'] = response.apply(lambda x: x and x['standard_address'])
+    df['lat'] = response.apply(lambda x: x and x['lat'])
+    df['lng'] = response.apply(lambda x: x and x['lng'])
+
+    latlng = pd.Series(list(zip(df['lat'], df['lng'])))
+    df['final_tract'] = latlng.apply(lambda x: latlng_to_polygon(x, tracts))
+    
+    print(df.to_csv(index=False)) 
+
+def smartystreets_client_builder():
+    """
+    Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
+    credentials from the environment variables ``SMARTYSTREETS_AUTH_ID`` and
+    ``SMARTYSTREETS_AUTH_TOKEN``.
+    """
+    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
+    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
+
+    return ClientBuilder(StaticCredentials(auth_id, auth_token))
+
+def lookup_address(address: str) -> dict:
+    """
+    Given an address, returns a dict containing a standardized address and 
+    lat/long coordinates from SmartyStreet's US Street geocoding API.
+    """
+    client = smartystreets_client_builder().build_us_street_api_client()
+
+    lookup = Lookup()
+    lookup.street = address
+    lookup.candidates = 1
+    lookup.match = "Invalid"  # Most permissive
+    
+    try:
+        client.send_lookup(lookup)
+    except exceptions.SmartyException as err:
+        LOG.exception(err)
+        return
+
+    result = lookup.result
+    if not result:  # Invalid address
+        result = extract_address(address)
+        if not result:
+            LOG.warning(f"Could not look up address {address}")
+            return 
+
+    first_candidate = result[0]
+
+    return {"standard_address": standard_address(first_candidate),
+            "lat": first_candidate.metadata.latitude,
+            "lng": first_candidate.metadata.longitude}
+
+def extract_address(text: str):
+    """
+    Given arbitrary *text*, returns a result from the SmartyStreet's US Extract
+    geocoding API containing information about an address connected to the text.
+
+    Note that this API is not consistent with the US Street API, and the lookup
+    and responses must be handled differently.
+    """
+    client = smartystreets_client_builder().build_us_extract_api_client()
+    lookup = ExtractLookup()
+    lookup.text = text
+
+    result = client.send(lookup)
+    metadata = result.metadata
+    
+    addresses = result.addresses
+    for address in addresses:
+        return address.candidates
+
+def standard_address(candidate) -> str:
+    """
+    Given a result object *candidate* from SmartyStreets geocoding API, return a 
+    standardized address.
+    """
+    standard_address = candidate.delivery_line_1
+    if candidate.delivery_line_2:
+        standard_address += ' ' + candidate.delivery_line_2
+
+    return standard_address + ' ' + candidate.last_line
 
 def load_geojson(geojson_filename):
     """Read GeoJSON file and return a list of features converted to shapes."""
@@ -65,23 +182,24 @@ def load_geojson(geojson_filename):
             for feature in geojson["features"]
     ]
 
-
-def latlng_to_polygon(latlng, polygons):
+def latlng_to_polygon(latlng: list, polygons):
     """
-    Find the first polygon in *polygons* which contains the *latlng* and return
-    the polygon, else None.
+    Find the first polygon in *polygons* (loaded from file) which contains the 
+    *latlng* and return the polygon, else None.
     """
-
+    
     # Ye olde lat/lng vs. lng/lat schism rears its head.
     lat, lng = latlng
+
     point = Point(lng, lat)
 
     for polygon in polygons:
         if polygon["shape"].contains(point):
-            return polygon
+            # GEOID is the nationally-unique tract identifier
+            return polygon.get("properties", {}).get("GEOID") 
 
+    LOG.warning(f"Failed to find tract for {latlng}")
     return None
-
 
 if __name__ == '__main__':
     main()

--- a/data/test/testset.csv
+++ b/data/test/testset.csv
@@ -1,0 +1,11 @@
+id,address,tract
+0,"1100 Fairview Ave N, Seattle, WA 98109", "53033006600"
+1,"1959 NE Pacific St, Seattle, WA 98195", "53033005302"
+2,"7755 E Marginal Way S, Seattle, WA 98108", "53033010900"
+3,"837 N 34th St #220, Seattle, WA 98103", "53033004900"
+4,"8864, 910 N Northlake Way, Seattle, WA 98103", "53033005400"
+5,"2360 43rd Ave E, Seattle, WA 98112", "53033006300"
+6,"7312 West Green Lake Dr N, Seattle, WA 98103", "53033004600"
+7,"3801 Discovery Park Blvd, Seattle, WA 98199", "53033005700"
+8,"5900 Lake Washington Blvd S, Seattle, WA 98118", "53033010200"
+9,"4025 Delridge Way SW #400, Seattle, WA 98106", "53033009900"

--- a/data/test/testset.csv
+++ b/data/test/testset.csv
@@ -1,0 +1,11 @@
+address,tract
+"1100 Fairview Ave N, Seattle, WA 98109",          "53033006600"
+"1959 NE Pacific St, Seattle, WA 98195",           "53033005302"
+"7755 E Marginal Way S, Seattle, WA 98108",        "53033010900"
+"837 N 34th St #220, Seattle, WA 98103",           "53033004900"
+"8864, 910 N Northlake Way, Seattle, WA 98103",    "53033005400"
+"2360 43rd Ave E, Seattle, WA 98112",              "53033006300"
+"7312 West Green Lake Dr N, Seattle, WA 98103",    "53033004600"
+"3801 Discovery Park Blvd, Seattle, WA 98199",     "53033005700"
+"5900 Lake Washington Blvd S, Seattle, WA 98118",  "53033010200"
+"4025 Delridge Way SW #400, Seattle, WA 98106",    "53033009900"

--- a/data/test/testset.json
+++ b/data/test/testset.json
@@ -1,10 +1,10 @@
-{"address": "1100 Fairview Ave N, Seattle, WA 98109",          "tract": "53033006600"}
-{"address": "1959 NE Pacific St, Seattle, WA 98195",           "tract": "53033005302"}
-{"address": "7755 E Marginal Way S, Seattle, WA 98108",        "tract": "53033010900"}
-{"address": "837 N 34th St #220, Seattle, WA 98103",           "tract": "53033004900"}
-{"address": "8864, 910 N Northlake Way, Seattle, WA 98103",    "tract": "53033005400"}
-{"address": "2360 43rd Ave E, Seattle, WA 98112",              "tract": "53033006300"}
-{"address": "7312 West Green Lake Dr N, Seattle, WA 98103",    "tract": "53033004600"}
-{"address": "3801 Discovery Park Blvd, Seattle, WA 98199",     "tract": "53033005700"}
-{"address": "5900 Lake Washington Blvd S, Seattle, WA 98118",  "tract": "53033010200"}
-{"address": "4025 Delridge Way SW #400, Seattle, WA 98106",    "tract": "53033009900"}
+{"id": 0, "address": "1959 NE Pacific St, Seattle, WA 98195",           "tract": "53033005302"}
+{"id": 1, "address": "7755 E Marginal Way S, Seattle, WA 98108",        "tract": "53033010900"}
+{"id": 2, "address": "837 N 34th St #220, Seattle, WA 98103",           "tract": "53033004900"}
+{"id": 3, "address": "1100 Fairview Ave N, Seattle, WA 98109",          "tract": "53033006600"}
+{"id": 4, "address": "8864, 910 N Northlake Way, Seattle, WA 98103",    "tract": "53033005400"}
+{"id": 5, "address": "2360 43rd Ave E, Seattle, WA 98112",              "tract": "53033006300"}
+{"id": 6, "address": "7312 West Green Lake Dr N, Seattle, WA 98103",    "tract": "53033004600"}
+{"id": 7, "address": "3801 Discovery Park Blvd, Seattle, WA 98199",     "tract": "53033005700"}
+{"id": 8, "address": "5900 Lake Washington Blvd S, Seattle, WA 98118",  "tract": "53033010200"}
+{"id": 9, "address": "4025 Delridge Way SW #400, Seattle, WA 98106",    "tract": "53033009900"}

--- a/geocoding_env_conda.yaml
+++ b/geocoding_env_conda.yaml
@@ -4,7 +4,8 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- geocoder
 - shapely
 - python=3.6*
 - snakemake
+- pandas
+- xlrd

--- a/geocoding_env_conda.yaml
+++ b/geocoding_env_conda.yaml
@@ -4,7 +4,7 @@ channels:
 - bioconda
 - defaults
 dependencies:
-- geocoder
 - shapely
 - python=3.6*
 - snakemake
+- pandas

--- a/src/address_to_census_tract.py
+++ b/src/address_to_census_tract.py
@@ -187,7 +187,7 @@ def process_csv_or_excel(file_path: str, address_map: dict):
     
     # Drop identifiable address columns
     df = df.drop(columns=address_columns + ['lat', 'lng'])
-    df.to_csv('data/test/out.csv', index=False) 
+    print(df.to_csv(index=False)) 
 
 def lookup_address(address: dict, address_map: dict) -> dict:
     """
@@ -199,11 +199,7 @@ def lookup_address(address: dict, address_map: dict) -> dict:
     broken into pieces (street, city, zipcode, etc.) or is a free text lookup 
     (and only the `street` parameter is used).
     """
-    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
-    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
-
-    credentials = StaticCredentials(auth_id, auth_token)
-    client = ClientBuilder(credentials).build_us_street_api_client()
+    client = smartystreets_client_builder().build_us_street_api_client()
     
     lookup = us_street_lookup(address, address_map)
     if not lookup.street:
@@ -213,49 +209,8 @@ def lookup_address(address: dict, address_map: dict) -> dict:
         """))
         return
 
-def process_csv(file_path: str):
-    """
-    Given a *file_path* to a CSV, processes the `address` column and adds 
-    extra columns for a standardized address, latitude and longitude
-    coordinates, and census tract. If a given address is invalid, these new 
-    columns are left blank. Dumps the new table to stdout. 
+        lookup = Lookup()
 
-    To minimize costs, an address should only be looked up once (via 
-    `lookup_address()`).
-    """
-    df = pd.read_csv(file_path)
-    tracts = load_geojson("data/geojsons/Washington_2016.geojson")
-
-    response = pd.Series(df['address'].apply(lookup_address))
-
-    # Parse response object to create columns of interest
-    df['standard_address'] = response.apply(lambda x: x and x['standard_address'])
-    df['lat'] = response.apply(lambda x: x and x['lat'])
-    df['lng'] = response.apply(lambda x: x and x['lng'])
-
-    latlng = pd.Series(list(zip(df['lat'], df['lng'])))
-    df['final_tract'] = latlng.apply(lambda x: latlng_to_polygon(x, tracts))
-    
-    print(df.to_csv(index=False)) 
-
-def smartystreets_client_builder():
-    """
-    Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
-    credentials from the environment variables ``SMARTYSTREETS_AUTH_ID`` and
-    ``SMARTYSTREETS_AUTH_TOKEN``.
-    """
-    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
-    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
-
-    return ClientBuilder(StaticCredentials(auth_id, auth_token))
-
-def lookup_address(address: str) -> dict:
-    """
-    Given an address, returns a dict containing a standardized address and 
-    lat/long coordinates from SmartyStreet's US Street geocoding API.
-    """
-
-    lookup = Lookup()
     lookup.street = address
     lookup.candidates = 1
     lookup.match = "Invalid"  # Most permissive
@@ -272,7 +227,7 @@ def lookup_address(address: str) -> dict:
         No match found for given address. Extracting address from text
         """))
         address_values = ', '.join([ str(val) for val in list(address.values()) if val ])
-        result = extract_address(credentials, address_values) 
+        result = extract_address(address_values) 
         if not result:
             LOG.warning(dedent(f"""
             Could not look up address {address}.
@@ -281,6 +236,17 @@ def lookup_address(address: str) -> dict:
 
     return {"lat": result[0].metadata.latitude,
             "lng": result[0].metadata.longitude}
+
+def smartystreets_client_builder():
+    """
+    Returns a new :class:`smartystreets_python_sdk.ClientBuilder` using
+    credentials from the environment variables ``SMARTYSTREETS_AUTH_ID`` and
+    ``SMARTYSTREETS_AUTH_TOKEN``.
+    """
+    auth_id = os.environ['SMARTYSTREETS_AUTH_ID']
+    auth_token = os.environ['SMARTYSTREETS_AUTH_TOKEN']
+
+    return ClientBuilder(StaticCredentials(auth_id, auth_token))
 
 def us_street_lookup(address: dict, api_map: dict) -> Lookup:
     """
@@ -308,18 +274,17 @@ def us_street_lookup(address: dict, api_map: dict) -> Lookup:
     lookup.match = "Invalid"  # Most permissive
     return lookup
     
-def extract_address(credentials, text: str):
+def extract_address(text: str):
     """
-    Given arbitrary *text* and *credentials* to SmartyStreets' geocoding APIs, 
-    returns a result from the SmartyStreets US Extract API containing 
-    information about an address connected to the text.
+    Given arbitrary *text*, returns a result from the SmartyStreets US Extract 
+    API containing information about an address connected to the text.
 
     Note that this API is not consistent with the US Street API, and the lookup
     and responses must be handled differently.
 
     Assumes addresses are given in the correct order # TODO enforce
     """
-    client = ClientBuilder(credentials).build_us_extract_api_client()
+    client = smartystreets_client_builder().build_us_extract_api_client()
     lookup = ExtractLookup()
     lookup.text = text
 
@@ -333,7 +298,7 @@ def latlng_to_polygon(latlng: list, polygons):
     Find the first polygon in *polygons* (loaded from file) which contains the 
     *latlng* and return the polygon, else None.
     """
-    
+
     # Ye olde lat/lng vs. lng/lat schism rears its head.
     lat, lng = latlng
 
@@ -348,47 +313,6 @@ def latlng_to_polygon(latlng: list, polygons):
     Failed to find tract for {latlng}.
     """))
     return None
-    if not result:  # Invalid address
-        result = extract_address(address)
-        if not result:
-            LOG.warning(f"Could not look up address {address}")
-            return 
-
-    first_candidate = result[0]
-
-    return {"standard_address": standard_address(first_candidate),
-            "lat": first_candidate.metadata.latitude,
-            "lng": first_candidate.metadata.longitude}
-
-def extract_address(text: str):
-    """
-    Given arbitrary *text*, returns a result from the SmartyStreet's US Extract
-    geocoding API containing information about an address connected to the text.
-
-    Note that this API is not consistent with the US Street API, and the lookup
-    and responses must be handled differently.
-    """
-    client = smartystreets_client_builder().build_us_extract_api_client()
-    lookup = ExtractLookup()
-    lookup.text = text
-
-    result = client.send(lookup)
-    metadata = result.metadata
-    
-    addresses = result.addresses
-    for address in addresses:
-        return address.candidates
-
-def standard_address(candidate) -> str:
-    """
-    Given a result object *candidate* from SmartyStreets geocoding API, return a 
-    standardized address.
-    """
-    standard_address = candidate.delivery_line_1
-    if candidate.delivery_line_2:
-        standard_address += ' ' + candidate.delivery_line_2
-
-    return standard_address + ' ' + candidate.last_line
 
 def load_geojson(geojson_filename):
     """Read GeoJSON file and return a list of features converted to shapes."""

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -1,0 +1,9 @@
+import timeit
+from address_to_census_tract import lookup_address
+import config
+
+default = config.ADDRESS_CONFIG['default']
+
+one = timeit.timeit('lookup_address({"address": "2718 14th Ave S Apt B, Seattle, WA 98144"}, default)', number=1)
+print(one)
+# 0.0012873420000687474

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,20 @@
+ADDRESS_CONFIG = {
+ 'uw': {
+    'street': 'AddressLine1',
+    'street2': 'AddressLine2',
+    'secondary': 'AddressLine3',
+    'city': 'City',
+    'state': 'StateText',
+    'zipcode': 'PostalCode'
+    },
+ 'sch': {},
+ 'kp': {},
+ 'default': {
+     'street': 'address',
+     'street2': None,
+     'secondary': None,
+     'city': None,
+     'state': None,
+     'zipcode': None
+ }
+}


### PR DESCRIPTION
This version of the geocoding program accepts multiple command line arguments for on-the-fly configuration. Known collaborators (such as UW), can pass their institute acronym to the 'institute' option to load saved configuration. 